### PR TITLE
filter unwanted props before spreading it  to HTML element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,24 @@ class TextComponent extends AppComponent {
     elemProps.style = Object.assign(this.getDefaultStyle() || {}, {
       color: this.getPropertyData('color') || 'black',
     });
+      //Filter out unwanted props
+      const {
+          componentData,
+          isDragging,
+          canAcceptDrop,
+          hasChildren,
+          getComponent,
+          getComponentType,
+          getComponentPropertyData,
+          setPropertyData,
+          moveUI,
+          moveInto,
+          setHoverObject,
+          hoverObject,
+          ...props
+      } = elemProps;
     return (
-      <div className="node" {...elemProps}>
+      <div className="node" {...props}>
         {this.getPropertyData('size') === 'heading' && (
           <h1> {this.getPropertyData('text') || 'Default Text Content'} </h1>
         )}


### PR DESCRIPTION
Clears all console errors when you use `Flow-App-Component-Text` by removing all unwanted props which do not meet the naming convention of React props on HTML elements.